### PR TITLE
Remove Signature of @DinisCruz

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ Aram Hovsepyan, [OWASP SAMM](https://www.owaspsamm.org) core team member<br>
 Brian Glas, [OWASP Top 10](https://owasp.org/www-project-top-ten/) Co-Lead, [OWASP SAMM](https://www.owaspsamm.org) Core team member, OWASP SAMM Benchmark Co-Lead<br>
 Jeff Williams, OWASP Chair from 2001-2011, Creator of OWASP Top Ten, WebGoat, ESAPI, ASVS, XSS Prevention Cheatsheet, OWASP Legal, Chapters Program, OWASP Foundation, the OWASP Wiki, and more<br>
 Dimitar Raichev, [OWASP SAMM](https://www.owaspsamm.org) contributor & tool developer<br>
-Dinis Cruz, Past OWASP Board member, organiser of multiple OWASP Conferences and Summits, lead multiple OWASP projects and chapters<br>
 Sachin Kumar Dhaka, OWASP Jaipur Member and Budding Security Researcher<br> 
 Jessy Ayala, OWASP Member and Contributor<br>
 Paul McCann, [OWASP Security Shepherd](https://github.com/OWASP/SecurityShepherd) maintainer and contributor<br>


### PR DESCRIPTION
@DinisCruz published ["Why OWASP can't pay OWASP Leaders"](http://diniscruz.blogspot.com/2012/04/why-owasp-cant-pay-owasp-leaders.html) as an @OWASP Board Member.

@vanderaj opposed @DinisCruz's policy on the [OWASP Leaders Mailing List](https://lists.owasp.org/pipermail/owasp-leaders/2012-April/007178) as an @OWASP Project Leader which has been reproduced below:

`Dinis,`
` `
`So essentially, the only folks who can't get paid are those who do. the.`
`work.`
` `
`No worries. Loud and clear.`
` `
`I must remember that the next time I think I want to sign up to sit in my`
`office for months on end away from my family and friends.`
` `
`thanks,`
`Andrew`

It is unfair that @vanderaj, as an @OWASP Board Member today (2023), should be tainted by, and carry the burden of,  @DinisCruz's [politics](http://diniscruz.blogspot.com/2012/04/why-owasp-cant-pay-owasp-leaders.html).

Therefore, @DinisCruz's signature must be removed as his position is ["... OWASP can't pay OWASP Leaders"](http://diniscruz.blogspot.com/2012/04/why-owasp-cant-pay-owasp-leaders.html) otherwise it will undermine @owasp-change